### PR TITLE
[ENG-1183] Resolve issue where rejected TCs kept Tasks in pending state

### DIFF
--- a/acp/internal/controller/task/task_controller.go
+++ b/acp/internal/controller/task/task_controller.go
@@ -194,7 +194,7 @@ func (r *TaskReconciler) processToolCalls(ctx context.Context, task *acp.Task) (
 	// Check if all tool calls are completed
 	allCompleted := true
 	for _, tc := range toolCalls.Items {
-		if tc.Status.Phase != acp.TaskRunToolCallPhaseSucceeded {
+		if tc.Status.Status != acp.TaskRunToolCallStatusTypeSucceeded {
 			allCompleted = false
 			break
 		}

--- a/acp/internal/controller/task/task_controller_test.go
+++ b/acp/internal/controller/task/task_controller_test.go
@@ -466,10 +466,18 @@ var _ = Describe("Task Controller", func() {
 			defer testTask.Teardown(ctx)
 
 			testTaskRunToolCall.SetupWithStatus(ctx, acp.TaskRunToolCallStatus{
+				Status: acp.TaskRunToolCallStatusTypeSucceeded,
 				Phase:  acp.TaskRunToolCallPhaseSucceeded,
 				Result: `{"data": "test-data"}`,
 			})
 			defer testTaskRunToolCall.Teardown(ctx)
+
+			testTaskRunToolCallTwo.SetupWithStatus(ctx, acp.TaskRunToolCallStatus{
+				Status: acp.TaskRunToolCallStatusTypeSucceeded,
+				Phase:  acp.TaskRunToolCallPhaseToolCallRejected,
+				Result: `human contact channel rejected this tool call with the following response: "I'm out here just testing things okay, try again later."`,
+			})
+			defer testTaskRunToolCallTwo.Teardown(ctx)
 
 			By("reconciling the task")
 			reconciler, recorder := reconciler()
@@ -487,9 +495,11 @@ var _ = Describe("Task Controller", func() {
 			ExpectRecorder(recorder).ToEmitEventContaining("AllToolCallsCompleted")
 
 			// todo expect the context window has the tool call result appended
-			Expect(task.Status.ContextWindow).To(HaveLen(4))
+			Expect(task.Status.ContextWindow).To(HaveLen(5))
 			Expect(task.Status.ContextWindow[3].Role).To(Equal("tool"))
 			Expect(task.Status.ContextWindow[3].Content).To(ContainSubstring("test-data"))
+			Expect(task.Status.ContextWindow[4].Role).To(Equal("tool"))
+			Expect(task.Status.ContextWindow[4].Content).To(ContainSubstring("I'm out here just testing things okay, try again later."))
 		})
 	})
 	Context("LLMFinalAnswer -> LLMFinalAnswer", func() {

--- a/acp/internal/controller/task/utils_test.go
+++ b/acp/internal/controller/task/utils_test.go
@@ -247,6 +247,10 @@ var testTaskRunToolCall = &TestTaskRunToolCall{
 	name: "test-taskrun-toolcall",
 }
 
+var testTaskRunToolCallTwo = &TestTaskRunToolCall{
+	name: "test-taskrun-toolcall-two",
+}
+
 // nolint:golint,unparam
 func setupSuiteObjects(ctx context.Context) (secret *corev1.Secret, llm *acp.LLM, agent *acp.Agent, teardown func()) {
 	secret = testSecret.Setup(ctx)

--- a/acp/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/acp/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -441,7 +441,8 @@ func (r *TaskRunToolCallReconciler) updateTRTCStatus(ctx context.Context, trtc *
 
 	// Store the result for tool call rejection
 	if trtcStatusPhase == acp.TaskRunToolCallPhaseToolCallRejected {
-		trtcDeepCopy.Status.Result = result
+		toolName := trtc.Spec.ToolRef.Name
+		trtcDeepCopy.Status.Result = fmt.Sprintf("User denied `%s` with feedback: %s", toolName, result)
 	}
 
 	if err := r.Status().Update(ctx, trtcDeepCopy); err != nil {

--- a/acp/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/acp/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -434,7 +434,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			Expect(updatedTRTC.Status.Phase).To(Equal(acp.TaskRunToolCallPhaseToolCallRejected))
 			Expect(updatedTRTC.Status.Status).To(Equal(acp.TaskRunToolCallStatusTypeSucceeded))
 			Expect(updatedTRTC.Status.StatusDetail).To(ContainSubstring("Tool execution rejected"))
-			Expect(updatedTRTC.Status.Result).To(Equal(rejectionComment))
+			Expect(updatedTRTC.Status.Result).To(ContainSubstring(rejectionComment))
 		})
 	})
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue where rejected tool calls kept tasks in pending state by updating status handling in `task_controller.go` and `taskruntoolcall_controller.go`.
> 
>   - **Behavior**:
>     - Fixes issue where rejected tool calls kept tasks in pending state by updating status handling in `task_controller.go` and `taskruntoolcall_controller.go`.
>     - Updates `processToolCalls()` in `task_controller.go` to check `Status` instead of `Phase` for completion.
>     - Modifies `updateTRTCStatus()` in `taskruntoolcall_controller.go` to append rejection comments to `Result`.
>   - **Tests**:
>     - Adds test cases in `task_controller_test.go` and `taskruntoolcall_controller_test.go` to verify behavior for rejected tool calls.
>     - Updates existing tests to reflect changes in status handling.
>   - **Misc**:
>     - Updates image tag in `kustomization.yaml` from `202504071305` to `202504072043`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fkubechain&utm_source=github&utm_medium=referral)<sup> for 1f8c6fa2c71e73247eb3e58b84e771a60955ec8f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->