### PR TITLE
Implement Human ContactChannel integration for using humans as tools during Task runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,7 +1058,7 @@ Events:
 
 For certain workflows, you may desire humans to provide non-deterministic input (in contrast to the deterministic behavior described in the "Human Approval" workflow above). For these operations, ACP provides support via [HumanLayer's](https://github.com/humanlayer/humanlayer) [Human as Tool](https://www.humanlayer.dev/docs/core/human-as-tool) feature set.
 
-**Note**: We recommend running through the above examples first prior exploring this section. Several Kubernetes resources created in that section will be assumed to exist.
+**Note**: This example builds on prior examples, and assumes you've already created base objects like Secrets, LLMs.
 
 We're going to create a new `Agent` and related `Task`, but before we can do that, we'll want a new `ContactChannel` to work with:
 

--- a/README.md
+++ b/README.md
@@ -1071,7 +1071,7 @@ cat <<EOF | kubectl apply -f -
 apiVersion: acp.humanlayer.dev/v1alpha1 
 kind: ContactChannel
 metadata:
-  name: frodo-baggins-expert
+  name: human-expert
 spec:
   type: email
   apiKeyFrom:
@@ -1080,8 +1080,8 @@ spec:
       key: HUMANLAYER_API_KEY
   email:
     address: "$MY_EMAIL"
-    subject: "Frodo Baggins Knowledge Request" 
-    contextAboutUser: "Expert on all things related to the Lord of the Rings character, Frodo Baggins"
+    subject: "Request for Expertise" 
+    contextAboutUser: "A human expert that can provide a wide-range answers on a variety of topics"
 EOF
 ```
 
@@ -1101,7 +1101,7 @@ spec:
   mcpServers:
     - name: fetch
   humanContactChannels:
-    - name: frodo-baggins-expert
+    - name: human-expert
 EOF
 ```
 
@@ -1112,29 +1112,15 @@ cat <<EOF | kubectl apply -f -
 apiVersion: acp.humanlayer.dev/v1alpha1 
 kind: Task
 metadata:
-  name: baggins-task
+  name: human-expert-task
 spec:
   agentRef:
     name: agent-with-human-tool
-  userMessage: "Learn about the character found at https://lotrapi.co/api/v1/characters/1. If the character is Frodo Baggins, consult an expert for extra knowledge. Provide final information about the character in the form of a haiku."
+  userMessage: "Ask an expert what the the fastest animal on the planet is."
 EOF
 ```
 
-Conversely, the following request should not:
-
-```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: acp.humanlayer.dev/v1alpha1 
-kind: Task
-metadata:
-  name: gandalf-task
-spec:
-  agentRef:
-    name: agent-with-human-tool
-  userMessage: "Learn about the character found at https://lotrapi.co/api/v1/characters/3. If the character is Frodo Baggins, consult an expert for extra knowledge. Provide final information about the character in the form of a haiku."
-EOF
-```
-
+Provided, you've setup your `ContactChannel` correctly, you should receive an email requesting your expertise. Feel free to respond when ready and keep an eye on how your `Task` and `ToolCall` statuses changes as the answer is picked up.
 
 
 ### Open Telemetry support

--- a/acp/api/v1alpha1/toolcall_types.go
+++ b/acp/api/v1alpha1/toolcall_types.go
@@ -86,7 +86,7 @@ type ToolCallStatus struct {
 }
 
 // ToolCallPhase represents the phase of a ToolCall
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool;ErrorRequestingHumanApproval;ToolCallRejected
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool;ErrorRequestingHumanApproval;ErrorRequestingHumanInput;ToolCallRejected
 type ToolCallPhase string
 
 const (
@@ -108,6 +108,8 @@ const (
 	ToolCallPhaseReadyToExecuteApprovedTool ToolCallPhase = "ReadyToExecuteApprovedTool"
 	// ToolCallPhaseErrorRequestingHumanApproval indicates there was an error requesting human approval
 	ToolCallPhaseErrorRequestingHumanApproval ToolCallPhase = "ErrorRequestingHumanApproval"
+	// ToolCallPhaseErrorRequestingHumanInput indicates there was an error requesting human input
+	ToolCallPhaseErrorRequestingHumanInput ToolCallPhase = "ErrorRequestingHumanInput"
 	// ToolCallPhaseToolCallRejected indicates the tool call was rejected by human approval
 	ToolCallPhaseToolCallRejected ToolCallPhase = "ToolCallRejected"
 )

--- a/acp/config/crd/bases/acp.humanlayer.dev_toolcalls.yaml
+++ b/acp/config/crd/bases/acp.humanlayer.dev_toolcalls.yaml
@@ -122,6 +122,7 @@ spec:
                 - AwaitingHumanApproval
                 - ReadyToExecuteApprovedTool
                 - ErrorRequestingHumanApproval
+                - ErrorRequestingHumanInput
                 - ToolCallRejected
                 type: string
               ready:

--- a/acp/config/samples/acp_v1alpha_contactchannel_with_approval.yaml
+++ b/acp/config/samples/acp_v1alpha_contactchannel_with_approval.yaml
@@ -23,6 +23,8 @@ metadata:
   name: gpt-4o
 spec:
   provider: openai
+  parameters: 
+    model: "gpt-4o"
   apiKeyFrom:
     secretKeyRef:
       name: openai

--- a/acp/internal/controller/toolcall/toolcall_controller.go
+++ b/acp/internal/controller/toolcall/toolcall_controller.go
@@ -380,10 +380,10 @@ func (r *ToolCallReconciler) getMCPServer(ctx context.Context, tc *acp.ToolCall)
 }
 
 // getContactChannel fetches and validates the ContactChannel resource
-func (r *ToolCallReconciler) getContactChannel(ctx context.Context, channelName string, trtcNamespace string) (*acp.ContactChannel, error) {
+func (r *ToolCallReconciler) getContactChannel(ctx context.Context, channelName string, tcNamespace string) (*acp.ContactChannel, error) {
 	var contactChannel acp.ContactChannel
 	if err := r.Get(ctx, client.ObjectKey{
-		Namespace: trtcNamespace,
+		Namespace: tcNamespace,
 		Name:      channelName,
 	}, &contactChannel); err != nil {
 

--- a/acp/internal/controller/toolcall/toolcall_controller.go
+++ b/acp/internal/controller/toolcall/toolcall_controller.go
@@ -768,7 +768,16 @@ func (r *ToolCallReconciler) handleHumanContactFlow(ctx context.Context, tc *acp
 	}
 
 	tcNamespace := tc.Namespace
-	contactChannel, err := r.getContactChannel(ctx, tc.Spec.ToolRef.Name, tcNamespace)
+	toolName := tc.Spec.ToolRef.Name
+	// Split toolName to get channel name from format CHANNEL_NAME__TOOLNAME
+	parts := strings.Split(toolName, "__")
+	if len(parts) != 2 {
+		result, errStatus, _ := r.setStatusError(ctx, acp.ToolCallPhaseErrorRequestingHumanInput,
+			"InvalidToolName", tc, fmt.Errorf("invalid tool name format: %s", toolName))
+		return result, errStatus, true
+	}
+	channelName := parts[0]
+	contactChannel, err := r.getContactChannel(ctx, channelName, tcNamespace)
 	if err != nil {
 		result, errStatus, _ := r.setStatusError(ctx, acp.ToolCallPhaseErrorRequestingHumanInput,
 			"NoContactChannel", tc, err)

--- a/acp/internal/controller/toolcall/utils_test.go
+++ b/acp/internal/controller/toolcall/utils_test.go
@@ -391,7 +391,7 @@ func setupTestHumanContactResources(ctx context.Context, config *SetupTestHumanC
 
 	toolCall := &TestToolCall{
 		name:      name,
-		toolName:  testContactChannel.name, // For human contact, we reference the contact channel directly
+		toolName:  fmt.Sprintf("%s__%s", testContactChannel.name, testHumanContactTool.name),
 		arguments: args,
 		toolType:  acp.ToolTypeHumanContact,
 	}

--- a/acp/internal/controller/toolcall/utils_test.go
+++ b/acp/internal/controller/toolcall/utils_test.go
@@ -66,11 +66,11 @@ func (t *TestContactChannel) Setup(ctx context.Context) *acp.ContactChannel {
 	}
 
 	// Add specific config based on channel type
-	if t.channelType == "slack" {
+	if t.channelType == acp.ContactChannelTypeSlack {
 		contactChannel.Spec.Slack = &acp.SlackChannelConfig{
 			ChannelOrUserID: "C12345678",
 		}
-	} else if t.channelType == "email" {
+	} else if t.channelType == acp.ContactChannelTypeEmail {
 		contactChannel.Spec.Email = &acp.EmailChannelConfig{
 			Address: "test@example.com",
 		}

--- a/acp/internal/humanlayer/mock_hlclient.go
+++ b/acp/internal/humanlayer/mock_hlclient.go
@@ -130,3 +130,13 @@ func (m *MockHumanLayerClientWrapper) RequestApproval(ctx context.Context) (*hum
 	// Return a successful mock response
 	return &humanlayerapi.FunctionCallOutput{}, m.parent.StatusCode, nil
 }
+
+// RequestHumanContact implements HumanLayerClientWrapper
+func (m *MockHumanLayerClientWrapper) RequestHumanContact(ctx context.Context, userMsg string) (*humanlayerapi.HumanContactOutput, int, error) {
+	return nil, m.parent.StatusCode, m.parent.ReturnError
+}
+
+// GetHumanContactStatus implements HumanLayerClientWrapper
+func (m *MockHumanLayerClientWrapper) GetHumanContactStatus(ctx context.Context) (*humanlayerapi.HumanContactOutput, int, error) {
+	return nil, m.parent.StatusCode, m.parent.ReturnError
+}

--- a/acp/internal/llmclient/llm_client.go
+++ b/acp/internal/llmclient/llm_client.go
@@ -74,18 +74,17 @@ func ToolFromContactChannel(channel acp.ContactChannel) *Tool {
 	// Customize based on channel type
 	switch channel.Spec.Type {
 	case acp.ContactChannelTypeEmail:
-		name = fmt.Sprintf("human_contact_email_%s", channel.Name)
+		name = fmt.Sprintf("%s__human_contact_email", channel.Name)
 		description = channel.Spec.Email.ContextAboutUser
 
 	case acp.ContactChannelTypeSlack:
-		name = fmt.Sprintf("human_contact_slack_%s", channel.Name)
+		name = fmt.Sprintf("%s__human_contact_slack", channel.Name)
 		description = channel.Spec.Slack.ContextAboutChannelOrUser
 
 	default:
-		name = fmt.Sprintf("human_contact_%s", channel.Name)
+		name = fmt.Sprintf("%s__human_contact", channel.Name)
 		description = fmt.Sprintf("Contact a human via %s channel", channel.Spec.Type)
 	}
-
 	// Create the Tool
 	return &Tool{
 		Type: "function",


### PR DESCRIPTION
Replaces #65 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR adds support for using humans as tools in ACP tasks, allowing tasks to request human input via contact channels.
> 
>   - **Behavior**:
>     - Adds support for `HumanContact` tool type in `toolcall_controller.go`, allowing tasks to request human input via contact channels.
>     - Updates `ToolCallPhase` and `ToolCallStatusType` enums in `toolcall_types.go` to include `ErrorRequestingHumanInput`.
>     - Implements `handleHumanContactFlow()` and `requestHumanContact()` in `toolcall_controller.go` to manage human contact requests.
>   - **API and CRD**:
>     - Updates `toolcall_types.go` and `acp.humanlayer.dev_toolcalls.yaml` to define new phases and statuses for tool calls.
>     - Adds `ToolTypeHumanContact` to `ToolType` enum in `toolcall_types.go`.
>   - **Testing**:
>     - Adds test cases in `toolcall_controller_test.go` for `HumanContact` tool type, including success and failure scenarios.
>     - Updates `utils_test.go` to include setup and teardown for `HumanContact` tool resources.
>   - **Documentation**:
>     - Updates `README.md` to include a section on incorporating humans as tools, with examples of setting up contact channels and tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fagentcontrolplane&utm_source=github&utm_medium=referral)<sup> for ad21895ff6d97adf9e6308897df6bbffcdce0878. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->