### PR TITLE
Test refac

### DIFF
--- a/acp/internal/controller/task/task_controller_test.go
+++ b/acp/internal/controller/task/task_controller_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Task Controller", func() {
 			_, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
-			task := testTask.Setup(ctx)
+			task := testTask.Setup(ctx, k8sClient)
 			defer testTask.Teardown(ctx)
 
 			By("reconciling the task")
@@ -31,13 +31,13 @@ var _ = Describe("Task Controller", func() {
 			// reconciler.Tracer = noop.NewTracerProvider().Tracer("test") // Tracer is now set in reconciler() helper
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			By("checking the reconciler result")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeTrue()) // Expect requeue after initialization
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			By("checking the task status")
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseInitializing))
 			Expect(task.Status.SpanContext).NotTo(BeNil())
@@ -47,7 +47,7 @@ var _ = Describe("Task Controller", func() {
 	})
 	Context("Initializing -> Error", func() {
 		It("moves to error if the agent is not found", func() {
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseInitializing,
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -61,14 +61,14 @@ var _ = Describe("Task Controller", func() {
 
 			// First reconcile (should handle Initializing -> Pending/Error)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Expect requeue after 5 seconds because agent is not found
 			Expect(result.RequeueAfter).To(Equal(time.Second * 5))
 
 			By("checking the task status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhasePending)) // Should move to Pending while waiting
 			Expect(task.Status.StatusDetail).To(ContainSubstring("Waiting for Agent to exist"))
 			ExpectRecorder(recorder).ToEmitEventContaining("Waiting")
@@ -76,7 +76,7 @@ var _ = Describe("Task Controller", func() {
 	})
 	Context("Initializing -> Pending", func() {
 		It("moves to pending if upstream agent does not exist", func() {
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseInitializing,
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -90,24 +90,24 @@ var _ = Describe("Task Controller", func() {
 
 			// First reconcile (should handle Initializing -> Pending)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(time.Second * 5))
 
 			By("checking the task status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhasePending))
 			Expect(task.Status.StatusDetail).To(ContainSubstring("Waiting for Agent to exist"))
 			ExpectRecorder(recorder).ToEmitEventContaining("Waiting")
 		})
 		It("moves to pending if upstream agent is not ready", func() {
-			_ = testAgent.SetupWithStatus(ctx, acp.AgentStatus{
+			_ = testAgent.SetupWithStatus(ctx, k8sClient, acp.AgentStatus{
 				Ready: false,
 			})
 			defer testAgent.Teardown(ctx)
 
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseInitializing,
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -121,13 +121,13 @@ var _ = Describe("Task Controller", func() {
 
 			// First reconcile (should handle Initializing -> Pending)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(time.Second * 5))
 
 			By("checking the task status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhasePending))
 			Expect(task.Status.StatusDetail).To(ContainSubstring("Waiting for agent \"test-agent\" to become ready"))
 			ExpectRecorder(recorder).ToEmitEventContaining("Waiting for agent")
@@ -135,19 +135,19 @@ var _ = Describe("Task Controller", func() {
 	})
 	Context("Initializing -> ReadyForLLM", func() {
 		It("moves to ReadyForLLM if there is a userMessage + agentRef", func() {
-			testAgent.SetupWithStatus(ctx, acp.AgentStatus{
+			testAgent.SetupWithStatus(ctx, k8sClient, acp.AgentStatus{
 				Status: "Ready",
 				Ready:  true,
 			})
 			defer testAgent.Teardown(ctx)
 
 			testTask2 := &TestTask{
-				name:        "test-task-2",
-				agentName:   testAgent.name,
-				userMessage: "test-user-message",
+				Name:        "test-task-2",
+				AgentName:   testAgent.Name,
+				UserMessage: "test-user-message",
 			}
 			// Start with Initializing phase and span context
-			task := testTask2.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask2.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseInitializing,
 				SpanContext: &acp.SpanContext{
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -160,7 +160,7 @@ var _ = Describe("Task Controller", func() {
 			reconciler, recorder := reconciler()
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask2.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask2.Name, Namespace: "default"},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -168,11 +168,11 @@ var _ = Describe("Task Controller", func() {
 			Expect(result.Requeue).To(BeTrue())
 
 			By("ensuring the context window is set correctly after first reconcile")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask2.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask2.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseReadyForLLM)) // Should transition here
 			Expect(task.Status.ContextWindow).To(HaveLen(2))
 			Expect(task.Status.ContextWindow[0].Role).To(Equal("system"))
-			Expect(task.Status.ContextWindow[0].Content).To(ContainSubstring(testAgent.system))
+			Expect(task.Status.ContextWindow[0].Content).To(ContainSubstring(testAgent.SystemPrompt))
 			Expect(task.Status.ContextWindow[1].Role).To(Equal("user"))
 			Expect(task.Status.ContextWindow[1].Content).To(ContainSubstring("test-user-message"))
 			ExpectRecorder(recorder).ToEmitEventContaining("ValidationSucceeded")
@@ -183,13 +183,13 @@ var _ = Describe("Task Controller", func() {
 	})
 	Context("Pending -> ReadyForLLM", func() {
 		It("moves to ReadyForLLM if upstream dependencies are ready", func() {
-			testAgent.SetupWithStatus(ctx, acp.AgentStatus{
+			testAgent.SetupWithStatus(ctx, k8sClient, acp.AgentStatus{
 				Status: "Ready",
 				Ready:  true,
 			})
 			defer testAgent.Teardown(ctx)
 
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhasePending, // Start from Pending
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -203,21 +203,21 @@ var _ = Describe("Task Controller", func() {
 
 			// Reconcile (should handle Pending -> ReadyForLLM)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Expect requeue because prepareForLLM updates status and requeues
 			Expect(result.Requeue).To(BeTrue())
 
 			By("ensuring the context window is set correctly")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseReadyForLLM))
 			Expect(task.Status.StatusDetail).To(ContainSubstring("Ready to send to LLM"))
 			Expect(task.Status.ContextWindow).To(HaveLen(2))
 			Expect(task.Status.ContextWindow[0].Role).To(Equal("system"))
-			Expect(task.Status.ContextWindow[0].Content).To(ContainSubstring(testAgent.system))
+			Expect(task.Status.ContextWindow[0].Content).To(ContainSubstring(testAgent.SystemPrompt))
 			Expect(task.Status.ContextWindow[1].Role).To(Equal("user"))
-			Expect(task.Status.ContextWindow[1].Content).To(ContainSubstring(testTask.userMessage))
+			Expect(task.Status.ContextWindow[1].Content).To(ContainSubstring(testTask.UserMessage))
 			ExpectRecorder(recorder).ToEmitEventContaining("ValidationSucceeded")
 		})
 	})
@@ -226,7 +226,7 @@ var _ = Describe("Task Controller", func() {
 			_, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseReadyForLLM, // Start from ReadyForLLM
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -235,11 +235,11 @@ var _ = Describe("Task Controller", func() {
 				ContextWindow: []acp.Message{
 					{
 						Role:    "system",
-						Content: testAgent.system,
+						Content: testAgent.SystemPrompt,
 					},
 					{
 						Role:    "user",
-						Content: testTask.userMessage,
+						Content: testTask.UserMessage,
 					},
 				},
 			})
@@ -259,7 +259,7 @@ var _ = Describe("Task Controller", func() {
 
 			// Reconcile (should handle ReadyForLLM -> LLMFinalAnswer)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Expect no requeue because it reached a final state
@@ -267,7 +267,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(result.RequeueAfter).To(BeZero()) // Explicitly check RequeueAfter
 
 			By("ensuring the task status is updated with the llm final answer")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseFinalAnswer))
 			Expect(task.Status.StatusDetail).To(ContainSubstring("LLM final response received"))
 			Expect(task.Status.Output).To(Equal("The moon is a natural satellite of the Earth and lacks any formal government or capital."))
@@ -280,9 +280,9 @@ var _ = Describe("Task Controller", func() {
 			Expect(mockLLMClient.Calls).To(HaveLen(1))
 			Expect(mockLLMClient.Calls[0].Messages).To(HaveLen(2))
 			Expect(mockLLMClient.Calls[0].Messages[0].Role).To(Equal("system"))
-			Expect(mockLLMClient.Calls[0].Messages[0].Content).To(ContainSubstring(testAgent.system))
+			Expect(mockLLMClient.Calls[0].Messages[0].Content).To(ContainSubstring(testAgent.SystemPrompt))
 			Expect(mockLLMClient.Calls[0].Messages[1].Role).To(Equal("user"))
-			Expect(mockLLMClient.Calls[0].Messages[1].Content).To(ContainSubstring(testTask.userMessage))
+			Expect(mockLLMClient.Calls[0].Messages[1].Content).To(ContainSubstring(testTask.UserMessage))
 		})
 	})
 	Context("ReadyForLLM -> Error", func() {
@@ -290,7 +290,7 @@ var _ = Describe("Task Controller", func() {
 			_, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseReadyForLLM, // Start from ReadyForLLM
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -299,11 +299,11 @@ var _ = Describe("Task Controller", func() {
 				ContextWindow: []acp.Message{
 					{
 						Role:    "system",
-						Content: testAgent.system,
+						Content: testAgent.SystemPrompt,
 					},
 					{
 						Role:    "user",
-						Content: testTask.userMessage,
+						Content: testTask.UserMessage,
 					},
 				},
 			})
@@ -320,12 +320,12 @@ var _ = Describe("Task Controller", func() {
 
 			// Reconcile (should handle ReadyForLLM -> Error)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).To(HaveOccurred()) // Expect the error to be returned for requeue
 
 			By("checking the task status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Status).To(Equal(acp.TaskStatusTypeError))
 			// Phase shouldn't be Failed for general errors, should remain ReadyForLLM
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseReadyForLLM))
@@ -337,7 +337,7 @@ var _ = Describe("Task Controller", func() {
 			_, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseReadyForLLM, // Start from ReadyForLLM
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -346,11 +346,11 @@ var _ = Describe("Task Controller", func() {
 				ContextWindow: []acp.Message{
 					{
 						Role:    "system",
-						Content: testAgent.system,
+						Content: testAgent.SystemPrompt,
 					},
 					{
 						Role:    "user",
-						Content: testTask.userMessage,
+						Content: testTask.UserMessage,
 					},
 				},
 			})
@@ -371,7 +371,7 @@ var _ = Describe("Task Controller", func() {
 
 			// Reconcile (should handle ReadyForLLM -> Failed)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			// Expect NO error returned because the status is updated to Failed (terminal)
 			Expect(err).NotTo(HaveOccurred())
@@ -379,7 +379,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(result.RequeueAfter).To(BeZero())
 
 			By("checking the task status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Status).To(Equal(acp.TaskStatusTypeError))
 			// Phase should be Failed for 4xx errors
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseFailed))
@@ -401,7 +401,7 @@ var _ = Describe("Task Controller", func() {
 			_, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseReadyForLLM, // Start from ReadyForLLM
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -429,14 +429,14 @@ var _ = Describe("Task Controller", func() {
 
 			// Reconcile (should handle ReadyForLLM -> ToolCallsPending)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Expect requeue after 5 seconds because tool calls were created
 			Expect(result.RequeueAfter).To(Equal(time.Second * 5))
 
 			By("ensuring the task status is updated with the tool calls pending")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseToolCallsPending))
 			Expect(task.Status.StatusDetail).To(ContainSubstring("LLM response received, tool calls pending"))
 			ExpectRecorder(recorder).ToEmitEventContaining("SendingContextWindowToLLM", "ToolCallsPending")
@@ -444,7 +444,7 @@ var _ = Describe("Task Controller", func() {
 			By("ensuring the tool call was created")
 			toolCalls := &acp.ToolCallList{}
 			Expect(k8sClient.List(ctx, toolCalls, client.InNamespace("default"), client.MatchingLabels{
-				"acp.humanlayer.dev/task": testTask.name,
+				"acp.humanlayer.dev/task": testTask.Name,
 			})).To(Succeed())
 			Expect(toolCalls.Items).To(HaveLen(1))
 			Expect(toolCalls.Items[0].Spec.ToolRef.Name).To(Equal("fetch__fetch"))
@@ -465,7 +465,7 @@ var _ = Describe("Task Controller", func() {
 			_, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase:             acp.TaskPhaseToolCallsPending, // Start from ToolCallsPending
 				ToolCallRequestID: "test123",
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
@@ -485,14 +485,14 @@ var _ = Describe("Task Controller", func() {
 
 			// Reconcile (should handle ToolCallsPending -> ToolCallsPending)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Expect requeue after 5 seconds because tool calls are still pending
 			Expect(result.RequeueAfter).To(Equal(time.Second * 5))
 
 			By("checking the task status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseToolCallsPending)) // Should remain in this phase
 		})
 	})
@@ -502,7 +502,7 @@ var _ = Describe("Task Controller", func() {
 			defer teardown()
 
 			By("setting up the task with a tool call pending")
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase:             acp.TaskPhaseToolCallsPending, // Start from ToolCallsPending
 				ToolCallRequestID: "test123",
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
@@ -512,11 +512,11 @@ var _ = Describe("Task Controller", func() {
 				ContextWindow: []acp.Message{
 					{
 						Role:    "system",
-						Content: testAgent.system,
+						Content: testAgent.SystemPrompt,
 					},
 					{
 						Role:    "user",
-						Content: testTask.userMessage,
+						Content: testTask.UserMessage,
 					},
 					{
 						Role: "assistant",
@@ -574,14 +574,14 @@ var _ = Describe("Task Controller", func() {
 
 			// Reconcile (should handle ToolCallsPending -> ReadyForLLM)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Expect requeue because it moved to ReadyForLLLM
 			Expect(result.Requeue).To(BeTrue())
 
 			By("checking the task status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseReadyForLLM))
 			Expect(task.Status.StatusDetail).To(ContainSubstring("All tool calls completed, ready to send tool results to LLM"))
 			ExpectRecorder(recorder).ToEmitEventContaining("AllToolCallsCompleted")
@@ -616,7 +616,7 @@ var _ = Describe("Task Controller", func() {
 			_, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseFinalAnswer, // Start from FinalAnswer
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",
@@ -630,7 +630,7 @@ var _ = Describe("Task Controller", func() {
 
 			// Reconcile
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTask.name, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: testTask.Name, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Expect no requeue because it's a terminal state
@@ -638,7 +638,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(result.RequeueAfter).To(BeZero())
 
 			By("checking the task status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.name, Namespace: "default"}, task)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTask.Name, Namespace: "default"}, task)).To(Succeed())
 			Expect(task.Status.Phase).To(Equal(acp.TaskPhaseFinalAnswer)) // Should remain in FinalAnswer
 		})
 	})
@@ -663,7 +663,7 @@ var _ = Describe("Task Controller", func() {
 			testTaskName := fmt.Sprintf("multi-message-%s", uniqueSuffix)
 
 			By("setting up the task with an existing conversation history")
-			task := testTask.SetupWithStatus(ctx, acp.TaskStatus{
+			task := testTask.SetupWithStatus(ctx, k8sClient, acp.TaskStatus{
 				Phase: acp.TaskPhaseReadyForLLM,
 				SpanContext: &acp.SpanContext{ // Add a dummy span context
 					TraceID: "0af7651916cd43dd8448eb211c80319c",

--- a/acp/internal/controller/task/utils_test.go
+++ b/acp/internal/controller/task/utils_test.go
@@ -26,108 +26,17 @@ var testLLM = &utils.TestLLM{
 	SecretName: testSecret.Name,
 }
 
-type TestAgent struct {
-	name       string
-	llmName    string
-	system     string
-	mcpServers []acp.LocalObjectReference
-	agent      *acp.Agent
+var testAgent = &utils.TestAgent{
+	Name:         "test-agent",
+	LLMName:      testLLM.Name,
+	SystemPrompt: "you are a testing assistant",
+	MCPServers:   []acp.LocalObjectReference{},
 }
 
-func (t *TestAgent) Setup(ctx context.Context) *acp.Agent {
-	By("creating the agent")
-	agent := &acp.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: t.name,
-
-			Namespace: "default",
-		},
-		Spec: acp.AgentSpec{
-			LLMRef: acp.LocalObjectReference{
-				Name: t.llmName,
-			},
-			System:     t.system,
-			MCPServers: t.mcpServers,
-		},
-	}
-	err := k8sClient.Create(ctx, agent)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.name, Namespace: "default"}, agent)).To(Succeed())
-	t.agent = agent
-	return agent
-}
-
-func (t *TestAgent) SetupWithStatus(ctx context.Context, status acp.AgentStatus) *acp.Agent {
-	agent := t.Setup(ctx)
-	agent.Status = status
-	Expect(k8sClient.Status().Update(ctx, agent)).To(Succeed())
-	t.agent = agent
-	return agent
-}
-
-func (t *TestAgent) Teardown(ctx context.Context) {
-	By("deleting the agent")
-	Expect(k8sClient.Delete(ctx, t.agent)).To(Succeed())
-}
-
-var testAgent = &TestAgent{
-	name:       "test-agent",
-	llmName:    testLLM.Name,
-	system:     "you are a testing assistant",
-	mcpServers: []acp.LocalObjectReference{},
-}
-
-type TestTask struct {
-	name        string
-	agentName   string
-	userMessage string
-	task        *acp.Task
-}
-
-func (t *TestTask) Setup(ctx context.Context) *acp.Task {
-	By("creating the task")
-	task := &acp.Task{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      t.name,
-			Namespace: "default",
-		},
-		Spec: acp.TaskSpec{},
-	}
-	if t.agentName != "" {
-		task.Spec.AgentRef = acp.LocalObjectReference{
-			Name: t.agentName,
-		}
-	}
-	if t.userMessage != "" {
-		task.Spec.UserMessage = t.userMessage
-	}
-
-	err := k8sClient.Create(ctx, task)
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.name, Namespace: "default"}, task)).To(Succeed())
-	t.task = task
-	return task
-}
-
-func (t *TestTask) SetupWithStatus(ctx context.Context, status acp.TaskStatus) *acp.Task {
-	task := t.Setup(ctx)
-	task.Status = status
-	Expect(k8sClient.Status().Update(ctx, task)).To(Succeed())
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.name, Namespace: "default"}, task)).To(Succeed())
-	t.task = task
-	return task
-}
-
-func (t *TestTask) Teardown(ctx context.Context) {
-	By("deleting the task")
-	Expect(k8sClient.Delete(ctx, t.task)).To(Succeed())
-}
-
-var testTask = &TestTask{
-	name:        "test-task",
-	agentName:   "test-agent",
-	userMessage: "what is the capital of the moon?",
+var testTask = &utils.TestTask{
+	Name:        "test-task",
+	AgentName:   "test-agent",
+	UserMessage: "what is the capital of the moon?",
 }
 
 type TestToolCall struct {
@@ -142,13 +51,13 @@ func (t *TestToolCall) Setup(ctx context.Context) *acp.ToolCall {
 			Name:      t.name,
 			Namespace: "default",
 			Labels: map[string]string{
-				"acp.humanlayer.dev/task":            testTask.name,
+				"acp.humanlayer.dev/task":            testTask.Name,
 				"acp.humanlayer.dev/toolcallrequest": "test123",
 			},
 		},
 		Spec: acp.ToolCallSpec{
 			TaskRef: acp.LocalObjectReference{
-				Name: testTask.name,
+				Name: testTask.Name,
 			},
 			ToolRef: acp.LocalObjectReference{
 				Name: "test-tool",
@@ -186,12 +95,12 @@ var testToolCallTwo = &TestToolCall{
 
 // nolint:golint,unparam
 func setupSuiteObjects(ctx context.Context) (secret *corev1.Secret, llm *acp.LLM, agent *acp.Agent, teardown func()) {
-	secret = testSecret.Setup(ctx)
-	llm = testLLM.SetupWithStatus(ctx, acp.LLMStatus{
+	secret = testSecret.Setup(ctx, k8sClient)
+	llm = testLLM.SetupWithStatus(ctx, k8sClient, acp.LLMStatus{
 		Status: "Ready",
 		Ready:  true,
 	})
-	agent = testAgent.SetupWithStatus(ctx, acp.AgentStatus{
+	agent = testAgent.SetupWithStatus(ctx, k8sClient, acp.AgentStatus{
 		Status: "Ready",
 		Ready:  true,
 	})

--- a/acp/internal/controller/task/utils_test.go
+++ b/acp/internal/controller/task/utils_test.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+
 	"github.com/humanlayer/agentcontrolplane/acp/test/utils"
 
 	corev1 "k8s.io/api/core/v1"

--- a/acp/internal/controller/task/utils_test.go
+++ b/acp/internal/controller/task/utils_test.go
@@ -2,9 +2,8 @@ package task
 
 import (
 	"context"
+	"github.com/humanlayer/agentcontrolplane/acp/test/utils"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,36 +15,8 @@ import (
 	"github.com/humanlayer/agentcontrolplane/acp/internal/mcpmanager"
 )
 
-// todo this file should probably live in a shared package, but for now...
-type TestSecret struct {
-	name   string
-	secret *corev1.Secret
-}
-
-func (t *TestSecret) Setup(ctx context.Context) *corev1.Secret {
-	By("creating the secret")
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      t.name,
-			Namespace: "default",
-		},
-		Data: map[string][]byte{
-			"api-key": []byte("test-api-key"),
-		},
-	}
-	err := k8sClient.Create(ctx, secret)
-	Expect(err).NotTo(HaveOccurred())
-	t.secret = secret
-	return secret
-}
-
-func (t *TestSecret) Teardown(ctx context.Context) {
-	By("deleting the secret")
-	Expect(k8sClient.Delete(ctx, t.secret)).To(Succeed())
-}
-
-var testSecret = &TestSecret{
-	name: "test-secret",
+var testSecret = &utils.TestSecret{
+	Name: "test-secret",
 }
 
 type TestLLM struct {
@@ -64,7 +35,7 @@ func (t *TestLLM) Setup(ctx context.Context) *acp.LLM {
 			Provider: "openai",
 			APIKeyFrom: &acp.APIKeySource{
 				SecretKeyRef: acp.SecretKeyRef{
-					Name: testSecret.name,
+					Name: testSecret.Name,
 					Key:  "api-key",
 				},
 			},

--- a/acp/test/utils/agent.go
+++ b/acp/test/utils/agent.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"context"
+	"github.com/humanlayer/agentcontrolplane/acp/api/v1alpha1"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TestAgent struct {
+	Name         string
+	LLMName      string
+	SystemPrompt string
+	MCPServers   []v1alpha1.LocalObjectReference
+	Agent        *v1alpha1.Agent
+	k8sClient    client.Client
+}
+
+func (t *TestAgent) Setup(ctx context.Context, k8sClient client.Client) *v1alpha1.Agent {
+	t.k8sClient = k8sClient
+	ginkgo.By("creating the agent")
+	agent := &v1alpha1.Agent{
+		ObjectMeta: v1.ObjectMeta{
+			Name: t.Name,
+
+			Namespace: "default",
+		},
+		Spec: v1alpha1.AgentSpec{
+			LLMRef: v1alpha1.LocalObjectReference{
+				Name: t.LLMName,
+			},
+			System:     t.SystemPrompt,
+			MCPServers: t.MCPServers,
+		},
+	}
+	err := k8sClient.Create(ctx, agent)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.Name, Namespace: "default"}, agent)).To(gomega.Succeed())
+	t.Agent = agent
+	return agent
+}
+
+func (t *TestAgent) SetupWithStatus(ctx context.Context, k8sClient client.Client, status v1alpha1.AgentStatus) *v1alpha1.Agent {
+	agent := t.Setup(ctx, k8sClient)
+	agent.Status = status
+	gomega.Expect(t.k8sClient.Status().Update(ctx, agent)).To(gomega.Succeed())
+	t.Agent = agent
+	return agent
+}
+
+func (t *TestAgent) Teardown(ctx context.Context) {
+	if t.k8sClient == nil {
+		return
+	}
+	ginkgo.By("deleting the agent")
+	gomega.Expect(t.k8sClient.Delete(ctx, t.Agent)).To(gomega.Succeed())
+}

--- a/acp/test/utils/agent.go
+++ b/acp/test/utils/agent.go
@@ -2,10 +2,11 @@ package utils
 
 import (
 	"context"
+
 	"github.com/humanlayer/agentcontrolplane/acp/api/v1alpha1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -43,7 +44,11 @@ func (t *TestAgent) Setup(ctx context.Context, k8sClient client.Client) *v1alpha
 	return agent
 }
 
-func (t *TestAgent) SetupWithStatus(ctx context.Context, k8sClient client.Client, status v1alpha1.AgentStatus) *v1alpha1.Agent {
+func (t *TestAgent) SetupWithStatus(
+	ctx context.Context,
+	k8sClient client.Client,
+	status v1alpha1.AgentStatus,
+) *v1alpha1.Agent {
 	agent := t.Setup(ctx, k8sClient)
 	agent.Status = status
 	gomega.Expect(t.k8sClient.Status().Update(ctx, agent)).To(gomega.Succeed())

--- a/acp/test/utils/llm.go
+++ b/acp/test/utils/llm.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"context"
 	"github.com/humanlayer/agentcontrolplane/acp/api/v1alpha1"
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,7 +18,8 @@ type TestLLM struct {
 }
 
 func (t *TestLLM) Setup(ctx context.Context, k8sClient client.Client) *v1alpha1.LLM {
-	ginkgo.By("creating the llm")
+	t.k8sClient = k8sClient
+	By("creating the llm")
 	llm := &v1alpha1.LLM{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      t.Name,
@@ -35,8 +36,8 @@ func (t *TestLLM) Setup(ctx context.Context, k8sClient client.Client) *v1alpha1.
 		},
 	}
 	err := k8sClient.Create(ctx, llm)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.Name, Namespace: "default"}, llm)).To(gomega.Succeed())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.Name, Namespace: "default"}, llm)).To(Succeed())
 	t.LLM = llm
 	return llm
 }
@@ -44,7 +45,7 @@ func (t *TestLLM) Setup(ctx context.Context, k8sClient client.Client) *v1alpha1.
 func (t *TestLLM) SetupWithStatus(ctx context.Context, k8sClient client.Client, status v1alpha1.LLMStatus) *v1alpha1.LLM {
 	llm := t.Setup(ctx, k8sClient)
 	llm.Status = status
-	gomega.Expect(k8sClient.Status().Update(ctx, llm)).To(gomega.Succeed())
+	Expect(k8sClient.Status().Update(ctx, llm)).To(Succeed())
 	t.LLM = llm
 	return llm
 }
@@ -53,6 +54,6 @@ func (t *TestLLM) Teardown(ctx context.Context) {
 	if t.k8sClient == nil {
 		return
 	}
-	ginkgo.By("deleting the llm")
-	gomega.Expect(t.k8sClient.Delete(ctx, t.LLM)).To(gomega.Succeed())
+	By("deleting the llm")
+	Expect(t.k8sClient.Delete(ctx, t.LLM)).To(Succeed())
 }

--- a/acp/test/utils/llm.go
+++ b/acp/test/utils/llm.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"context"
+	"github.com/humanlayer/agentcontrolplane/acp/api/v1alpha1"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TestLLM struct {
+	Name       string
+	SecretName string
+	LLM        *v1alpha1.LLM
+	k8sClient  client.Client
+}
+
+func (t *TestLLM) Setup(ctx context.Context, k8sClient client.Client) *v1alpha1.LLM {
+	ginkgo.By("creating the llm")
+	llm := &v1alpha1.LLM{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      t.Name,
+			Namespace: "default",
+		},
+		Spec: v1alpha1.LLMSpec{
+			Provider: "openai",
+			APIKeyFrom: &v1alpha1.APIKeySource{
+				SecretKeyRef: v1alpha1.SecretKeyRef{
+					Name: t.SecretName,
+					Key:  "api-key",
+				},
+			},
+		},
+	}
+	err := k8sClient.Create(ctx, llm)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.Name, Namespace: "default"}, llm)).To(gomega.Succeed())
+	t.LLM = llm
+	return llm
+}
+
+func (t *TestLLM) SetupWithStatus(ctx context.Context, k8sClient client.Client, status v1alpha1.LLMStatus) *v1alpha1.LLM {
+	llm := t.Setup(ctx, k8sClient)
+	llm.Status = status
+	gomega.Expect(k8sClient.Status().Update(ctx, llm)).To(gomega.Succeed())
+	t.LLM = llm
+	return llm
+}
+
+func (t *TestLLM) Teardown(ctx context.Context) {
+	if t.k8sClient == nil {
+		return
+	}
+	ginkgo.By("deleting the llm")
+	gomega.Expect(t.k8sClient.Delete(ctx, t.LLM)).To(gomega.Succeed())
+}

--- a/acp/test/utils/llm.go
+++ b/acp/test/utils/llm.go
@@ -2,10 +2,11 @@ package utils
 
 import (
 	"context"
+
 	"github.com/humanlayer/agentcontrolplane/acp/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -42,7 +43,11 @@ func (t *TestLLM) Setup(ctx context.Context, k8sClient client.Client) *v1alpha1.
 	return llm
 }
 
-func (t *TestLLM) SetupWithStatus(ctx context.Context, k8sClient client.Client, status v1alpha1.LLMStatus) *v1alpha1.LLM {
+func (t *TestLLM) SetupWithStatus(
+	ctx context.Context,
+	k8sClient client.Client,
+	status v1alpha1.LLMStatus,
+) *v1alpha1.LLM {
 	llm := t.Setup(ctx, k8sClient)
 	llm.Status = status
 	Expect(k8sClient.Status().Update(ctx, llm)).To(Succeed())

--- a/acp/test/utils/objects_utils.go
+++ b/acp/test/utils/objects_utils.go
@@ -12,6 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type TestUtils struct {
+	K8sClient client.Client
+}
+
 type TestScopedAgent struct {
 	Name                 string
 	SystemPrompt         string

--- a/acp/test/utils/secret.go
+++ b/acp/test/utils/secret.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/acp/test/utils/secret.go
+++ b/acp/test/utils/secret.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TestSecret struct {
+	Name      string
+	Secret    *v1.Secret
+	k8sClient client.Client
+}
+
+func (t *TestSecret) Setup(ctx context.Context, k8sClient client.Client) *v1.Secret {
+	t.k8sClient = k8sClient
+
+	By("creating the secret")
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.Name,
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"api-key": []byte("test-api-key"),
+		},
+	}
+	err := k8sClient.Create(ctx, secret)
+	Expect(err).NotTo(HaveOccurred())
+	t.Secret = secret
+	return secret
+}
+
+func (t *TestSecret) Teardown(ctx context.Context) {
+	if t.k8sClient == nil {
+		return
+	}
+
+	By("deleting the secret")
+	Expect(t.k8sClient.Delete(ctx, t.Secret)).To(Succeed())
+}

--- a/acp/test/utils/task.go
+++ b/acp/test/utils/task.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/humanlayer/agentcontrolplane/acp/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TestTask struct {
+	Name        string
+	AgentName   string
+	UserMessage string
+	Task        *v1alpha1.Task
+	k8sClient   client.Client
+}
+
+func (t *TestTask) Setup(ctx context.Context, k8sClient client.Client) *v1alpha1.Task {
+	t.k8sClient = k8sClient
+	By("creating the task")
+	task := &v1alpha1.Task{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      t.Name,
+			Namespace: "default",
+		},
+		Spec: v1alpha1.TaskSpec{},
+	}
+	if t.AgentName != "" {
+		task.Spec.AgentRef = v1alpha1.LocalObjectReference{
+			Name: t.AgentName,
+		}
+	}
+	if t.UserMessage != "" {
+		task.Spec.UserMessage = t.UserMessage
+	}
+
+	err := k8sClient.Create(ctx, task)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.Name, Namespace: "default"}, task)).To(Succeed())
+	t.Task = task
+	return task
+}
+
+func (t *TestTask) SetupWithStatus(ctx context.Context, k8sClient client.Client, status v1alpha1.TaskStatus) *v1alpha1.Task {
+	task := t.Setup(ctx, k8sClient)
+	task.Status = status
+	Expect(t.k8sClient.Status().Update(ctx, task)).To(Succeed())
+	Expect(t.k8sClient.Get(ctx, types.NamespacedName{Name: t.Name, Namespace: "default"}, task)).To(Succeed())
+	t.Task = task
+	return task
+}
+
+func (t *TestTask) Teardown(ctx context.Context) {
+	if t.k8sClient == nil {
+		return
+	}
+	By("deleting the task")
+	Expect(t.k8sClient.Delete(ctx, t.Task)).To(Succeed())
+}

--- a/acp/test/utils/task.go
+++ b/acp/test/utils/task.go
@@ -46,7 +46,11 @@ func (t *TestTask) Setup(ctx context.Context, k8sClient client.Client) *v1alpha1
 	return task
 }
 
-func (t *TestTask) SetupWithStatus(ctx context.Context, k8sClient client.Client, status v1alpha1.TaskStatus) *v1alpha1.Task {
+func (t *TestTask) SetupWithStatus(
+	ctx context.Context,
+	k8sClient client.Client,
+	status v1alpha1.TaskStatus,
+) *v1alpha1.Task {
 	task := t.Setup(ctx, k8sClient)
 	task.Status = status
 	Expect(t.k8sClient.Status().Update(ctx, task)).To(Succeed())

--- a/acp/test/utils/utils.go
+++ b/acp/test/utils/utils.go
@@ -1,6 +1,7 @@
 /*
 Copyright 2025.
 
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor test resource setup/teardown into reusable helper structs in `acp/test/utils/` and update tests to use them.
> 
>   - **Test utility refactor**:
>     - Moves test setup/teardown logic for `Secret`, `LLM`, `Agent`, and `Task` from `utils_test.go` to new helper structs in `acp/test/utils/secret.go`, `llm.go`, `agent.go`, and `task.go`.
>     - Updates `task_controller_test.go` and `utils_test.go` to use new `TestSecret`, `TestLLM`, `TestAgent`, and `TestTask` helpers for resource creation and cleanup.
>   - **Test code changes**:
>     - All test resource setup/teardown now requires passing `k8sClient` explicitly.
>     - Test object fields renamed for consistency (e.g., `name` → `Name`, `system` → `SystemPrompt`, `userMessage` → `UserMessage`).
>     - Removes duplicated setup logic from `utils_test.go`.
>   - **Misc**:
>     - No changes to production code or test logic/behavior.
>     - Minor updates to `acp/test/utils/objects_utils.go` to add `TestUtils` struct (unused in this PR).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fagentcontrolplane&utm_source=github&utm_medium=referral)<sup> for ccaee1d00ea0a50af8cd4ab76a1e69ee3a6d9d2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->