### PR TITLE
Fixup MCP tools to support all possible parameter types

### DIFF
--- a/acp/config/manager/kustomization.yaml
+++ b/acp/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: example.com/acp
-  newTag: v0.0.1
+  newName: controller
+  newTag: "202504161541"

--- a/acp/config/manager/kustomization.yaml
+++ b/acp/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: "202504151521"
+  newName: example.com/acp
+  newTag: v0.0.1

--- a/acp/internal/adapters/mcp_adapter.go
+++ b/acp/internal/adapters/mcp_adapter.go
@@ -21,21 +21,21 @@ func ConvertMCPToolsToLLMClientTools(mcpTools []acp.MCPTool, serverName string) 
 
 		// Convert the input schema if available
 		if tool.InputSchema.Raw != nil {
-			var params llmclient.ToolFunctionParameters
+			var params map[string]interface{}
 			if err := json.Unmarshal(tool.InputSchema.Raw, &params); err == nil {
 				toolFunction.Parameters = params
 			} else {
 				// Default to a simple object schema if none provided
 				toolFunction.Parameters = llmclient.ToolFunctionParameters{
-					Type:       "object",
-					Properties: map[string]*llmclient.Schema{},
+					"type":       "object",
+					"properties": map[string]interface{}{},
 				}
 			}
 		} else {
 			// Default to a simple object schema if none provided
 			toolFunction.Parameters = llmclient.ToolFunctionParameters{
-				Type:       "object",
-				Properties: map[string]*llmclient.Schema{},
+				"type":       "object",
+				"properties": map[string]interface{}{},
 			}
 		}
 

--- a/acp/internal/adapters/mcp_adapter.go
+++ b/acp/internal/adapters/mcp_adapter.go
@@ -28,14 +28,14 @@ func ConvertMCPToolsToLLMClientTools(mcpTools []acp.MCPTool, serverName string) 
 				// Default to a simple object schema if none provided
 				toolFunction.Parameters = llmclient.ToolFunctionParameters{
 					Type:       "object",
-					Properties: map[string]llmclient.ToolFunctionParameter{},
+					Properties: map[string]*llmclient.Schema{},
 				}
 			}
 		} else {
 			// Default to a simple object schema if none provided
 			toolFunction.Parameters = llmclient.ToolFunctionParameters{
 				Type:       "object",
-				Properties: map[string]llmclient.ToolFunctionParameter{},
+				Properties: map[string]*llmclient.Schema{},
 			}
 		}
 

--- a/acp/internal/adapters/mcp_adapter_test.go
+++ b/acp/internal/adapters/mcp_adapter_test.go
@@ -72,12 +72,17 @@ var _ = Describe("MCP Adapter", func() {
 			Expect(clientTools).To(HaveLen(1))
 			tool := clientTools[0]
 			Expect(tool.Function.Name).To(Equal("test-server__process_list"))
-			Expect(tool.Function.Parameters.Type).To(Equal("object"))
-			Expect(tool.Function.Parameters.Properties).To(HaveKey("items"))
-			itemsSchema := tool.Function.Parameters.Properties["items"]
-			Expect(itemsSchema.Type).To(Equal("array"))
-			Expect(itemsSchema.Items).NotTo(BeNil())
-			Expect(itemsSchema.Items.Type).To(Equal("string"))
+
+			params := tool.Function.Parameters
+			Expect(params["type"]).To(Equal("object"))
+
+			properties := params["properties"].(map[string]interface{})
+			Expect(properties).To(HaveKey("items"))
+
+			itemsSchema := properties["items"].(map[string]interface{})
+			Expect(itemsSchema["type"]).To(Equal("array"))
+			Expect(itemsSchema["items"]).NotTo(BeNil())
+			Expect(itemsSchema["items"].(map[string]interface{})["type"]).To(Equal("string"))
 		})
 
 		It("converts a tool with a complex nested schema", func() {
@@ -112,20 +117,26 @@ var _ = Describe("MCP Adapter", func() {
 
 			Expect(clientTools).To(HaveLen(1))
 			tool := clientTools[0]
-			Expect(tool.Function.Parameters.Type).To(Equal("object"))
-			Expect(tool.Function.Parameters.Required).To(ContainElement("names"))
+
+			params := tool.Function.Parameters
+			Expect(params["type"]).To(Equal("object"))
+			Expect(params["required"]).To(ContainElement("names"))
+
+			properties := params["properties"].(map[string]interface{})
 
 			// Verify array parameter
-			namesSchema := tool.Function.Parameters.Properties["names"]
-			Expect(namesSchema.Type).To(Equal("array"))
-			Expect(namesSchema.Items).NotTo(BeNil())
-			Expect(namesSchema.Items.Type).To(Equal("string"))
+			namesSchema := properties["names"].(map[string]interface{})
+			Expect(namesSchema["type"]).To(Equal("array"))
+			Expect(namesSchema["items"]).NotTo(BeNil())
+			Expect(namesSchema["items"].(map[string]interface{})["type"]).To(Equal("string"))
 
 			// Verify nested object parameter
-			optionsSchema := tool.Function.Parameters.Properties["options"]
-			Expect(optionsSchema.Type).To(Equal("object"))
-			Expect(optionsSchema.Properties).NotTo(BeNil())
-			Expect(optionsSchema.Properties["flag"].Type).To(Equal("boolean"))
+			optionsSchema := properties["options"].(map[string]interface{})
+			Expect(optionsSchema["type"]).To(Equal("object"))
+
+			optionProperties := optionsSchema["properties"].(map[string]interface{})
+			Expect(optionProperties).NotTo(BeNil())
+			Expect(optionProperties["flag"].(map[string]interface{})["type"]).To(Equal("boolean"))
 
 			// Verify JSON serialization roundtrip
 			jsonBytes, err := json.Marshal(tool.Function.Parameters)
@@ -135,9 +146,66 @@ var _ = Describe("MCP Adapter", func() {
 			err = json.Unmarshal(jsonBytes, &unmarshalled)
 			Expect(err).NotTo(HaveOccurred())
 
-			properties := unmarshalled["properties"].(map[string]interface{})
+			properties = unmarshalled["properties"].(map[string]interface{})
 			Expect(properties).To(HaveKey("names"))
 			Expect(properties).To(HaveKey("options"))
+		})
+
+		It("handles complex JSON Schema constructs like anyOf", func() {
+			// Schema with anyOf construct
+			complexSchema := `{
+				"type": "object",
+				"properties": {
+					"options": {
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": ["option1", "option2"]
+							},
+							{
+								"type": "object",
+								"properties": {
+									"customOption": {
+										"type": "string"
+									}
+								},
+								"required": ["customOption"]
+							}
+						]
+					}
+				}
+			}`
+
+			mcpTool := acp.MCPTool{
+				Name:        "tool-with-anyof",
+				Description: "A tool with anyOf schema construct",
+				InputSchema: runtime.RawExtension{Raw: []byte(complexSchema)},
+			}
+
+			clientTools := ConvertMCPToolsToLLMClientTools([]acp.MCPTool{mcpTool}, "test-server")
+
+			Expect(clientTools).To(HaveLen(1))
+			tool := clientTools[0]
+			params := tool.Function.Parameters
+			properties := params["properties"].(map[string]interface{})
+
+			// Verify that the anyOf construct is preserved
+			optionsSchema := properties["options"].(map[string]interface{})
+			Expect(optionsSchema).To(HaveKey("anyOf"))
+
+			anyOfOptions := optionsSchema["anyOf"].([]interface{})
+			Expect(anyOfOptions).To(HaveLen(2))
+
+			// First option should be a string with enum values
+			firstOption := anyOfOptions[0].(map[string]interface{})
+			Expect(firstOption["type"]).To(Equal("string"))
+			Expect(firstOption["enum"]).To(ContainElements("option1", "option2"))
+
+			// Second option should be an object with nested properties
+			secondOption := anyOfOptions[1].(map[string]interface{})
+			Expect(secondOption["type"]).To(Equal("object"))
+			Expect(secondOption).To(HaveKey("properties"))
+			Expect(secondOption["required"]).To(ContainElement("customOption"))
 		})
 	})
 })

--- a/acp/internal/adapters/mcp_adapter_test.go
+++ b/acp/internal/adapters/mcp_adapter_test.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"encoding/json"
+
 	"k8s.io/apimachinery/pkg/runtime"
 
 	. "github.com/onsi/ginkgo/v2"

--- a/acp/internal/adapters/mcp_adapter_test.go
+++ b/acp/internal/adapters/mcp_adapter_test.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"encoding/json"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -58,6 +59,85 @@ var _ = Describe("MCP Adapter", func() {
 			serverName := "test-server"
 			result := ConvertMCPToolsToLLMClientTools([]acp.MCPTool{}, serverName)
 			Expect(result).To(BeEmpty())
+		})
+
+		It("converts a tool with an array parameter", func() {
+			mcpTool := acp.MCPTool{
+				Name:        "process_list",
+				Description: "Processes a list of items",
+				InputSchema: runtime.RawExtension{Raw: []byte(`{"type":"object","properties":{"items":{"type":"array","items":{"type":"string"}}}}`)},
+			}
+			clientTools := ConvertMCPToolsToLLMClientTools([]acp.MCPTool{mcpTool}, "test-server")
+
+			Expect(clientTools).To(HaveLen(1))
+			tool := clientTools[0]
+			Expect(tool.Function.Name).To(Equal("test-server__process_list"))
+			Expect(tool.Function.Parameters.Type).To(Equal("object"))
+			Expect(tool.Function.Parameters.Properties).To(HaveKey("items"))
+			itemsSchema := tool.Function.Parameters.Properties["items"]
+			Expect(itemsSchema.Type).To(Equal("array"))
+			Expect(itemsSchema.Items).NotTo(BeNil())
+			Expect(itemsSchema.Items.Type).To(Equal("string"))
+		})
+
+		It("converts a tool with a complex nested schema", func() {
+			complexSchema := `{
+				"type": "object",
+				"properties": {
+					"names": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"options": {
+						"type": "object",
+						"properties": {
+							"flag": {
+								"type": "boolean"
+							}
+						}
+					}
+				},
+				"required": ["names"]
+			}`
+
+			mcpTool := acp.MCPTool{
+				Name:        "complex-tool",
+				Description: "A tool with complex schema including arrays",
+				InputSchema: runtime.RawExtension{Raw: []byte(complexSchema)},
+			}
+
+			clientTools := ConvertMCPToolsToLLMClientTools([]acp.MCPTool{mcpTool}, "test-server")
+
+			Expect(clientTools).To(HaveLen(1))
+			tool := clientTools[0]
+			Expect(tool.Function.Parameters.Type).To(Equal("object"))
+			Expect(tool.Function.Parameters.Required).To(ContainElement("names"))
+
+			// Verify array parameter
+			namesSchema := tool.Function.Parameters.Properties["names"]
+			Expect(namesSchema.Type).To(Equal("array"))
+			Expect(namesSchema.Items).NotTo(BeNil())
+			Expect(namesSchema.Items.Type).To(Equal("string"))
+
+			// Verify nested object parameter
+			optionsSchema := tool.Function.Parameters.Properties["options"]
+			Expect(optionsSchema.Type).To(Equal("object"))
+			Expect(optionsSchema.Properties).NotTo(BeNil())
+			Expect(optionsSchema.Properties["flag"].Type).To(Equal("boolean"))
+
+			// Verify JSON serialization roundtrip
+			jsonBytes, err := json.Marshal(tool.Function.Parameters)
+			Expect(err).NotTo(HaveOccurred())
+
+			var unmarshalled map[string]interface{}
+			err = json.Unmarshal(jsonBytes, &unmarshalled)
+			Expect(err).NotTo(HaveOccurred())
+
+			properties := unmarshalled["properties"].(map[string]interface{})
+			Expect(properties).To(HaveKey("names"))
+			Expect(properties).To(HaveKey("options"))
 		})
 	})
 })

--- a/acp/internal/llmclient/llm_client.go
+++ b/acp/internal/llmclient/llm_client.go
@@ -45,32 +45,21 @@ type ToolFunction struct {
 	Parameters  ToolFunctionParameters `json:"parameters"`
 }
 
-// Schema represents a JSON Schema structure, supporting nested schemas for arrays and objects
-type Schema struct {
-	Type        string             `json:"type"`
-	Description string             `json:"description,omitempty"`
-	Enum        []interface{}      `json:"enum,omitempty"`
-	Items       *Schema            `json:"items,omitempty"`
-	Properties  map[string]*Schema `json:"properties,omitempty"`
-	Required    []string           `json:"required,omitempty"`
-}
-
 // ToolFunctionParameters defines the schema for the function parameters
-type ToolFunctionParameters struct {
-	Type       string             `json:"type"`
-	Properties map[string]*Schema `json:"properties"`
-	Required   []string           `json:"required,omitempty"`
-}
+// It's a map to accommodate any valid JSON Schema structure
+type ToolFunctionParameters map[string]interface{}
 
 // FromContactChannel creates a Tool from a ContactChannel resource
 func ToolFromContactChannel(channel acp.ContactChannel) *Tool {
 	// Create base parameters structure for human contact tools
 	params := ToolFunctionParameters{
-		Type: "object",
-		Properties: map[string]*Schema{
-			"message": &Schema{Type: "string"},
+		"type": "object",
+		"properties": map[string]interface{}{
+			"message": map[string]interface{}{
+				"type": "string",
+			},
 		},
-		Required: []string{"message"},
+		"required": []string{"message"},
 	}
 
 	var description string

--- a/acp/internal/llmclient/llm_client.go
+++ b/acp/internal/llmclient/llm_client.go
@@ -45,16 +45,21 @@ type ToolFunction struct {
 	Parameters  ToolFunctionParameters `json:"parameters"`
 }
 
-// ToolFunctionParameter defines a parameter type
-type ToolFunctionParameter struct {
-	Type string `json:"type"`
+// Schema represents a JSON Schema structure, supporting nested schemas for arrays and objects
+type Schema struct {
+	Type        string             `json:"type"`
+	Description string             `json:"description,omitempty"`
+	Enum        []interface{}      `json:"enum,omitempty"`
+	Items       *Schema            `json:"items,omitempty"`
+	Properties  map[string]*Schema `json:"properties,omitempty"`
+	Required    []string           `json:"required,omitempty"`
 }
 
 // ToolFunctionParameters defines the schema for the function parameters
 type ToolFunctionParameters struct {
-	Type       string                           `json:"type"`
-	Properties map[string]ToolFunctionParameter `json:"properties"`
-	Required   []string                         `json:"required,omitempty"`
+	Type       string             `json:"type"`
+	Properties map[string]*Schema `json:"properties"`
+	Required   []string           `json:"required,omitempty"`
 }
 
 // FromContactChannel creates a Tool from a ContactChannel resource
@@ -62,8 +67,8 @@ func ToolFromContactChannel(channel acp.ContactChannel) *Tool {
 	// Create base parameters structure for human contact tools
 	params := ToolFunctionParameters{
 		Type: "object",
-		Properties: map[string]ToolFunctionParameter{
-			"message": {Type: "string"},
+		Properties: map[string]*Schema{
+			"message": &Schema{Type: "string"},
 		},
 		Required: []string{"message"},
 	}

--- a/acp/internal/llmclient/llm_client_test.go
+++ b/acp/internal/llmclient/llm_client_test.go
@@ -1,0 +1,165 @@
+package llmclient
+
+import (
+	"encoding/json"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Schema", func() {
+	It("represents a simple string type", func() {
+		schema := &Schema{Type: "string"}
+		jsonData, err := json.Marshal(schema)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(jsonData)).To(Equal(`{"type":"string"}`))
+	})
+
+	It("represents an array of strings", func() {
+		schema := &Schema{
+			Type:  "array",
+			Items: &Schema{Type: "string"},
+		}
+		jsonData, err := json.Marshal(schema)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(jsonData)).To(MatchJSON(`{"type":"array","items":{"type":"string"}}`))
+	})
+
+	It("represents a nested object with an array", func() {
+		schema := &Schema{
+			Type: "object",
+			Properties: map[string]*Schema{
+				"items": {
+					Type:  "array",
+					Items: &Schema{Type: "string"},
+				},
+			},
+		}
+		jsonData, err := json.Marshal(schema)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(jsonData)).To(MatchJSON(`{"type":"object","properties":{"items":{"type":"array","items":{"type":"string"}}}}`))
+	})
+
+	It("includes enum values when provided", func() {
+		schema := &Schema{
+			Type: "string",
+			Enum: []interface{}{"option1", "option2", "option3"},
+		}
+		jsonData, err := json.Marshal(schema)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(jsonData)).To(MatchJSON(`{"type":"string","enum":["option1","option2","option3"]}`))
+	})
+
+	It("includes description when provided", func() {
+		schema := &Schema{
+			Type:        "boolean",
+			Description: "A flag indicating whether the feature is enabled",
+		}
+		jsonData, err := json.Marshal(schema)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(jsonData)).To(MatchJSON(`{"type":"boolean","description":"A flag indicating whether the feature is enabled"}`))
+	})
+})
+
+var _ = Describe("ToolFunctionParameters", func() {
+	It("represents a parameter with an array property", func() {
+		params := ToolFunctionParameters{
+			Type: "object",
+			Properties: map[string]*Schema{
+				"names": {
+					Type:  "array",
+					Items: &Schema{Type: "string"},
+				},
+			},
+			Required: []string{"names"},
+		}
+		jsonData, err := json.Marshal(params)
+		Expect(err).NotTo(HaveOccurred())
+		expected := `{"type":"object","properties":{"names":{"type":"array","items":{"type":"string"}}},"required":["names"]}`
+		Expect(string(jsonData)).To(MatchJSON(expected))
+	})
+
+	It("represents a nested object parameter", func() {
+		params := ToolFunctionParameters{
+			Type: "object",
+			Properties: map[string]*Schema{
+				"data": {
+					Type: "object",
+					Properties: map[string]*Schema{
+						"values": {
+							Type:  "array",
+							Items: &Schema{Type: "number"},
+						},
+					},
+				},
+			},
+		}
+		jsonData, err := json.Marshal(params)
+		Expect(err).NotTo(HaveOccurred())
+		expected := `{"type":"object","properties":{"data":{"type":"object","properties":{"values":{"type":"array","items":{"type":"number"}}}}}}`
+		Expect(string(jsonData)).To(MatchJSON(expected))
+	})
+
+	It("handles a complex schema with multiple properties and nested structures", func() {
+		params := ToolFunctionParameters{
+			Type: "object",
+			Properties: map[string]*Schema{
+				"name": {
+					Type:        "string",
+					Description: "The name of the item",
+				},
+				"tags": {
+					Type:        "array",
+					Description: "Tags associated with the item",
+					Items:       &Schema{Type: "string"},
+				},
+				"metadata": {
+					Type: "object",
+					Properties: map[string]*Schema{
+						"created": {Type: "string"},
+						"size":    {Type: "number"},
+						"features": {
+							Type: "array",
+							Items: &Schema{
+								Type: "object",
+								Properties: map[string]*Schema{
+									"id":      {Type: "string"},
+									"enabled": {Type: "boolean"},
+								},
+							},
+						},
+					},
+				},
+			},
+			Required: []string{"name", "metadata"},
+		}
+
+		jsonData, err := json.Marshal(params)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify JSON structure after unmarshaling
+		var result map[string]interface{}
+		err = json.Unmarshal(jsonData, &result)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(result["type"]).To(Equal("object"))
+
+		properties := result["properties"].(map[string]interface{})
+		Expect(properties["name"].(map[string]interface{})["type"]).To(Equal("string"))
+		Expect(properties["tags"].(map[string]interface{})["type"]).To(Equal("array"))
+
+		metadata := properties["metadata"].(map[string]interface{})
+		Expect(metadata["type"]).To(Equal("object"))
+
+		metadataProps := metadata["properties"].(map[string]interface{})
+		Expect(metadataProps["features"].(map[string]interface{})["type"]).To(Equal("array"))
+
+		// Check deeply nested array of objects
+		featuresItems := metadataProps["features"].(map[string]interface{})["items"].(map[string]interface{})
+		Expect(featuresItems["type"]).To(Equal("object"))
+		Expect(featuresItems["properties"].(map[string]interface{})["enabled"].(map[string]interface{})["type"]).To(Equal("boolean"))
+
+		required := result["required"].([]interface{})
+		Expect(required).To(ContainElement("name"))
+		Expect(required).To(ContainElement("metadata"))
+	})
+})

--- a/acp/internal/llmclient/llm_client_test.go
+++ b/acp/internal/llmclient/llm_client_test.go
@@ -2,6 +2,7 @@ package llmclient
 
 import (
 	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/acp/internal/llmclient/llm_client_test.go
+++ b/acp/internal/llmclient/llm_client_test.go
@@ -6,131 +6,80 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Schema", func() {
-	It("represents a simple string type", func() {
-		schema := &Schema{Type: "string"}
-		jsonData, err := json.Marshal(schema)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(jsonData)).To(Equal(`{"type":"string"}`))
-	})
-
-	It("represents an array of strings", func() {
-		schema := &Schema{
-			Type:  "array",
-			Items: &Schema{Type: "string"},
-		}
-		jsonData, err := json.Marshal(schema)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(jsonData)).To(MatchJSON(`{"type":"array","items":{"type":"string"}}`))
-	})
-
-	It("represents a nested object with an array", func() {
-		schema := &Schema{
-			Type: "object",
-			Properties: map[string]*Schema{
-				"items": {
-					Type:  "array",
-					Items: &Schema{Type: "string"},
-				},
-			},
-		}
-		jsonData, err := json.Marshal(schema)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(jsonData)).To(MatchJSON(`{"type":"object","properties":{"items":{"type":"array","items":{"type":"string"}}}}`))
-	})
-
-	It("includes enum values when provided", func() {
-		schema := &Schema{
-			Type: "string",
-			Enum: []interface{}{"option1", "option2", "option3"},
-		}
-		jsonData, err := json.Marshal(schema)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(jsonData)).To(MatchJSON(`{"type":"string","enum":["option1","option2","option3"]}`))
-	})
-
-	It("includes description when provided", func() {
-		schema := &Schema{
-			Type:        "boolean",
-			Description: "A flag indicating whether the feature is enabled",
-		}
-		jsonData, err := json.Marshal(schema)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(jsonData)).To(MatchJSON(`{"type":"boolean","description":"A flag indicating whether the feature is enabled"}`))
-	})
-})
-
-var _ = Describe("ToolFunctionParameters", func() {
-	It("represents a parameter with an array property", func() {
+var _ = Describe("Tool Function Parameters", func() {
+	It("represents a simple parameter", func() {
 		params := ToolFunctionParameters{
-			Type: "object",
-			Properties: map[string]*Schema{
-				"names": {
-					Type:  "array",
-					Items: &Schema{Type: "string"},
+			"type": "object",
+			"properties": map[string]interface{}{
+				"name": map[string]interface{}{
+					"type": "string",
 				},
 			},
-			Required: []string{"names"},
 		}
 		jsonData, err := json.Marshal(params)
 		Expect(err).NotTo(HaveOccurred())
-		expected := `{"type":"object","properties":{"names":{"type":"array","items":{"type":"string"}}},"required":["names"]}`
-		Expect(string(jsonData)).To(MatchJSON(expected))
+		Expect(string(jsonData)).To(MatchJSON(`{"type":"object","properties":{"name":{"type":"string"}}}`))
 	})
 
-	It("represents a nested object parameter", func() {
+	It("represents an array parameter", func() {
 		params := ToolFunctionParameters{
-			Type: "object",
-			Properties: map[string]*Schema{
-				"data": {
-					Type: "object",
-					Properties: map[string]*Schema{
-						"values": {
-							Type:  "array",
-							Items: &Schema{Type: "number"},
-						},
+			"type": "object",
+			"properties": map[string]interface{}{
+				"items": map[string]interface{}{
+					"type": "array",
+					"items": map[string]interface{}{
+						"type": "string",
 					},
 				},
 			},
 		}
 		jsonData, err := json.Marshal(params)
 		Expect(err).NotTo(HaveOccurred())
-		expected := `{"type":"object","properties":{"data":{"type":"object","properties":{"values":{"type":"array","items":{"type":"number"}}}}}}`
-		Expect(string(jsonData)).To(MatchJSON(expected))
+		Expect(string(jsonData)).To(MatchJSON(`{"type":"object","properties":{"items":{"type":"array","items":{"type":"string"}}}}`))
 	})
 
-	It("handles a complex schema with multiple properties and nested structures", func() {
+	It("represents a complex schema with nested objects and arrays", func() {
 		params := ToolFunctionParameters{
-			Type: "object",
-			Properties: map[string]*Schema{
-				"name": {
-					Type:        "string",
-					Description: "The name of the item",
+			"type": "object",
+			"properties": map[string]interface{}{
+				"name": map[string]interface{}{
+					"type":        "string",
+					"description": "The name of the item",
 				},
-				"tags": {
-					Type:        "array",
-					Description: "Tags associated with the item",
-					Items:       &Schema{Type: "string"},
+				"tags": map[string]interface{}{
+					"type":        "array",
+					"description": "Tags associated with the item",
+					"items": map[string]interface{}{
+						"type": "string",
+					},
 				},
-				"metadata": {
-					Type: "object",
-					Properties: map[string]*Schema{
-						"created": {Type: "string"},
-						"size":    {Type: "number"},
-						"features": {
-							Type: "array",
-							Items: &Schema{
-								Type: "object",
-								Properties: map[string]*Schema{
-									"id":      {Type: "string"},
-									"enabled": {Type: "boolean"},
+				"metadata": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"created": map[string]interface{}{
+							"type": "string",
+						},
+						"size": map[string]interface{}{
+							"type": "number",
+						},
+						"features": map[string]interface{}{
+							"type": "array",
+							"items": map[string]interface{}{
+								"type": "object",
+								"properties": map[string]interface{}{
+									"id": map[string]interface{}{
+										"type": "string",
+									},
+									"enabled": map[string]interface{}{
+										"type": "boolean",
+									},
 								},
 							},
 						},
 					},
 				},
 			},
-			Required: []string{"name", "metadata"},
+			"required": []string{"name", "metadata"},
 		}
 
 		jsonData, err := json.Marshal(params)
@@ -161,5 +110,53 @@ var _ = Describe("ToolFunctionParameters", func() {
 		required := result["required"].([]interface{})
 		Expect(required).To(ContainElement("name"))
 		Expect(required).To(ContainElement("metadata"))
+	})
+
+	It("handles complex JSON Schema constructs like anyOf", func() {
+		params := ToolFunctionParameters{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"options": map[string]interface{}{
+					"anyOf": []interface{}{
+						map[string]interface{}{
+							"type": "string",
+							"enum": []string{"option1", "option2"},
+						},
+						map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"customOption": map[string]interface{}{
+									"type": "string",
+								},
+							},
+							"required": []string{"customOption"},
+						},
+					},
+				},
+			},
+		}
+
+		jsonData, err := json.Marshal(params)
+		Expect(err).NotTo(HaveOccurred())
+
+		var result map[string]interface{}
+		err = json.Unmarshal(jsonData, &result)
+		Expect(err).NotTo(HaveOccurred())
+
+		properties := result["properties"].(map[string]interface{})
+		options := properties["options"].(map[string]interface{})
+		Expect(options).To(HaveKey("anyOf"))
+
+		anyOf := options["anyOf"].([]interface{})
+		Expect(anyOf).To(HaveLen(2))
+
+		firstOption := anyOf[0].(map[string]interface{})
+		Expect(firstOption["type"]).To(Equal("string"))
+		Expect(firstOption["enum"]).To(ContainElements("option1", "option2"))
+
+		secondOption := anyOf[1].(map[string]interface{})
+		Expect(secondOption["type"]).To(Equal("object"))
+		Expect(secondOption).To(HaveKey("properties"))
+		Expect(secondOption["required"]).To(ContainElement("customOption"))
 	})
 })

--- a/acp/internal/llmclient/suite_test.go
+++ b/acp/internal/llmclient/suite_test.go
@@ -1,0 +1,13 @@
+package llmclient
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLLMClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LLM Client Suite")
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance MCP tools to support all JSON Schema parameter types, including complex constructs like `anyOf`, with extensive testing.
> 
>   - **Behavior**:
>     - `ConvertMCPToolsToLLMClientTools` in `mcp_adapter.go` now supports all JSON Schema parameter types by using `map[string]interface{}` for `ToolFunctionParameters`.
>     - Handles complex JSON Schema constructs like `anyOf`.
>   - **Testing**:
>     - Added tests in `mcp_adapter_test.go` for array parameters, complex nested schemas, and `anyOf` constructs.
>     - Added `llm_client_test.go` to test `ToolFunctionParameters` with various JSON Schema structures.
>   - **Misc**:
>     - Updated `kustomization.yaml` to use new image tag `202504161541`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fagentcontrolplane&utm_source=github&utm_medium=referral)<sup> for 70b3b7a727eb3ac91df2470cf485e5b617bae16c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->