### PR TITLE
Add localdev kustomize to run API server

### DIFF
--- a/acp-example/kind/kind-config.yaml
+++ b/acp-example/kind/kind-config.yaml
@@ -29,6 +29,11 @@ nodes:
         hostPort: 9092
         listenAddress: "0.0.0.0"
         protocol: tcp
+      # ACP Controller Manager HTTP gateway
+      - containerPort: 8082
+        hostPort: 8082
+        listenAddress: "0.0.0.0"
+        protocol: tcp
 
 kubeadmConfigPatches:
   - |

--- a/acp/Makefile
+++ b/acp/Makefile
@@ -195,7 +195,7 @@ deploy: manifests docker-build kustomize ## Deploy controller to the K8s cluster
 .PHONY: deploy-local-kind
 deploy-local-kind: manifests docker-build docker-load-kind kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/localdev | $(KUBECTL) apply -f -
 
 .PHONY: deploy-samples
 deploy-samples: kustomize ## Deploy samples to the K8s cluster specified in ~/.kube/config.

--- a/acp/config/localdev/kustomization.yaml
+++ b/acp/config/localdev/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: default
+resources:
+  - ./service.yaml
+  - ../../config/default

--- a/acp/config/localdev/service.yaml
+++ b/acp/config/localdev/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-service
+spec:
+  type: NodePort
+  selector:
+    control-plane: controller-manager
+  ports:
+    - port: 8082
+      targetPort: 8082
+      nodePort: 8082
+      protocol: TCP
+      name: http
+

--- a/acp/config/manager/kustomization.yaml
+++ b/acp/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: controller
-  newTag: "202504161541"
+  newTag: "202504162159"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add local development setup using Kustomize to run API server with new service and configuration changes.
> 
>   - **Local Development Setup**:
>     - Adds `kustomization.yaml` and `service.yaml` in `acp/config/localdev/` for local development.
>     - `service.yaml` defines a `NodePort` service for `controller-manager` on port 8082.
>   - **Configuration Changes**:
>     - Updates `kind-config.yaml` to map port 8082 for ACP Controller Manager HTTP gateway.
>     - Modifies `Makefile` to use `config/localdev` for `deploy-local-kind` target.
>   - **Misc**:
>     - Updates image tag in `manager/kustomization.yaml` to `202504162159`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fagentcontrolplane&utm_source=github&utm_medium=referral)<sup> for 62c2f146db85ef83532ed71df2e33a8e5637a3f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->