### PR TITLE
approval required based on annotations

### DIFF
--- a/acp/api/v1alpha1/mcpserver_types.go
+++ b/acp/api/v1alpha1/mcpserver_types.go
@@ -86,6 +86,25 @@ const (
 	ResourceMemory ResourceName = "memory"
 )
 
+// ToolAnnotation contains metadata and hints about a tool's behavior
+type ToolAnnotation struct {
+	// If true, the tool does not modify its environment
+	// +optional
+	ReadOnlyHint *bool `json:"readOnlyHint,omitempty"`
+
+	// If true, the tool may perform destructive updates
+	// +optional
+	DestructiveHint *bool `json:"destructiveHint,omitempty"`
+
+	// If true, repeated calls with same args have no additional effect
+	// +optional
+	IdempotentHint *bool `json:"idempotentHint,omitempty"`
+
+	// If true, tool interacts with external entities
+	// +optional
+	OpenWorldHint *bool `json:"openWorldHint,omitempty"`
+}
+
 // MCPTool represents a tool provided by an MCP server
 type MCPTool struct {
 	// Name of the tool
@@ -100,6 +119,10 @@ type MCPTool struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	InputSchema runtime.RawExtension `json:"inputSchema,omitempty"`
+
+	// Annotations contains metadata and hints about the tool's behavior
+	// +optional
+	Annotations *ToolAnnotation `json:"annotations,omitempty"`
 }
 
 // MCPServerStatus defines the observed state of MCPServer

--- a/acp/api/v1alpha1/toolcall_types.go
+++ b/acp/api/v1alpha1/toolcall_types.go
@@ -42,6 +42,10 @@ type ToolCallSpec struct {
 	// Arguments contains the arguments for the tool call
 	// +kubebuilder:validation:Required
 	Arguments string `json:"arguments"`
+
+	// ToolAnnotations contains metadata about the tool's behavior
+	// +optional
+	ToolAnnotations *ToolAnnotation `json:"toolAnnotations,omitempty"`
 }
 
 // ToolCallStatus defines the observed state of ToolCall

--- a/acp/internal/adapters/mcp_adapter.go
+++ b/acp/internal/adapters/mcp_adapter.go
@@ -39,11 +39,12 @@ func ConvertMCPToolsToLLMClientTools(mcpTools []acp.MCPTool, serverName string) 
 			}
 		}
 
-		// Create the tool with the function definition
+		// Create the tool with the function definition and annotations
 		clientTools = append(clientTools, llmclient.Tool{
-			Type:        "function",
-			Function:    toolFunction,
-			ACPToolType: acp.ToolTypeMCP,
+			Type:               "function",
+			Function:           toolFunction,
+			ACPToolType:        acp.ToolTypeMCP,
+			ACPToolAnnotations: tool.Annotations,
 		})
 	}
 

--- a/acp/internal/controller/task/task_controller.go
+++ b/acp/internal/controller/task/task_controller.go
@@ -524,10 +524,12 @@ func (r *TaskReconciler) createToolCalls(ctx context.Context, task *acp.Task, st
 		return ctrl.Result{}, err
 	}
 
-	// Create a map of tool name to tool type for quick lookup
+	// Create maps for tool type and tool annotations for quick lookup
 	toolTypeMap := make(map[string]acp.ToolType)
+	toolAnnotationsMap := make(map[string]*acp.ToolAnnotation)
 	for _, tool := range tools {
 		toolTypeMap[tool.Function.Name] = tool.ACPToolType
+		toolAnnotationsMap[tool.Function.Name] = tool.ACPToolAnnotations
 	}
 
 	// For each tool call, create a new ToolCall with a unique name using the ToolCallRequestID
@@ -561,8 +563,9 @@ func (r *TaskReconciler) createToolCalls(ctx context.Context, task *acp.Task, st
 				ToolRef: acp.LocalObjectReference{
 					Name: tc.Function.Name,
 				},
-				ToolType:  toolTypeMap[tc.Function.Name],
-				Arguments: tc.Function.Arguments,
+				ToolType:         toolTypeMap[tc.Function.Name],
+				Arguments:        tc.Function.Arguments,
+				ToolAnnotations:  toolAnnotationsMap[tc.Function.Name],
 			},
 		}
 		if err := r.Client.Create(ctx, newTC); err != nil {

--- a/acp/internal/llmclient/llm_client.go
+++ b/acp/internal/llmclient/llm_client.go
@@ -36,6 +36,9 @@ type Tool struct {
 	// ACPToolType represents the ACP-specific type of tool (MCP, HumanContact)
 	// This field is not sent to the LLM API but is used internally for tool identification
 	ACPToolType acp.ToolType `json:"-"`
+	// ACPToolAnnotations contains metadata about the tool's behavior
+	// This field is not sent to the LLM API but is used internally for approval logic
+	ACPToolAnnotations *acp.ToolAnnotation `json:"-"`
 }
 
 // ToolFunction contains the function details

--- a/acp/internal/mcpmanager/mcpmanager.go
+++ b/acp/internal/mcpmanager/mcpmanager.go
@@ -199,10 +199,22 @@ func (m *MCPServerManager) ConnectServer(ctx context.Context, mcpServer *acp.MCP
 			}
 		}
 
+		// Create a ToolAnnotation object to preserve the annotations from the MCP tool
+		var annotations *acp.ToolAnnotation
+		if tool.Annotations != nil {
+			annotations = &acp.ToolAnnotation{
+				ReadOnlyHint:     tool.Annotations.ReadOnlyHint,
+				DestructiveHint:  tool.Annotations.DestructiveHint,
+				IdempotentHint:   tool.Annotations.IdempotentHint,
+				OpenWorldHint:    tool.Annotations.OpenWorldHint,
+			}
+		}
+
 		tools = append(tools, acp.MCPTool{
 			Name:        tool.Name,
 			Description: tool.Description,
 			InputSchema: runtime.RawExtension{Raw: inputSchemaBytes},
+			Annotations: annotations,
 		})
 	}
 


### PR DESCRIPTION
Pretty sloppy and in-process. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds tool approval logic based on annotations, updating controllers and managers to handle new metadata.
> 
>   - **Behavior**:
>     - Introduces `ToolAnnotation` struct in `mcpserver_types.go` and `toolcall_types.go` to store tool metadata.
>     - Updates `ToolCallReconciler` to handle tool approval based on annotations, including session-level approvals.
>     - Adds logic to `TaskReconciler` to manage tool calls with annotations.
>   - **Controllers**:
>     - `ToolCallReconciler` now checks `ToolAnnotation` for approval logic, including `ReadOnlyHint` to skip approvals.
>     - `TaskReconciler` creates tool calls with annotations and manages their execution.
>   - **Managers**:
>     - `MCPServerManager` updated to include tool annotations when listing tools.
>   - **Misc**:
>     - Adds `createToolApprovalRequest` function in `toolcall_controller.go` for building approval requests.
>     - Updates `llm_client.go` to include `ACPToolAnnotations` in `Tool` struct.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fagentcontrolplane&utm_source=github&utm_medium=referral)<sup> for 987031a2177669abc2b8b310a3ac497ad621771f. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->