### PR TITLE
remove workflow (not real)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:  # Use pull_request_target instead of pull_request
     types: [opened, synchronize]  # Runs on new PRs and updates
 
 jobs:
@@ -21,17 +21,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch full history for accurate diffs
+          # Important: For pull_request_target, ref needs to be explicitly set to PR head
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run Code Review with Claude
         id: code-review
         uses: anthropics/claude-code-action@beta
         with:
-          # Your GitHub token for API operations
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          
           # Define the review focus areas
           direct_prompt: "Review the PR changes. Focus on code quality, potential bugs, and performance issues. Suggest improvements where appropriate. Pay special attention to Kubernetes operator patterns and Go best practices according to the CLAUDE.md file."
 
+          # Your GitHub token for API operations
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          
           # Limited tools for safer review operations
           allowed_tools: |-
             # Git inspection commands (read-only)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,6 @@ jobs:
       discussions: write
       id-token: write
       statuses: write
-      workflow: write
       actions: write
     steps:
       # Check out the code to allow git diff operations

--- a/.github/workflows/claude-comment-response.yml
+++ b/.github/workflows/claude-comment-response.yml
@@ -15,7 +15,6 @@ jobs:
       discussions: write
       id-token: write
       statuses: write
-      workflow: write
       actions: write
     steps:
       - name: Checkout code

--- a/.github/workflows/claude-pr-creation.yml
+++ b/.github/workflows/claude-pr-creation.yml
@@ -20,7 +20,6 @@ jobs:
       discussions: write
       id-token: write
       statuses: write
-      workflow: write
       actions: write
     steps:
       - name: Checkout code


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `workflow: write` permission from three GitHub Actions workflows to enhance security.
> 
>   - **Permissions**:
>     - Remove `workflow: write` permission from `.github/workflows/claude-code-review.yml`, `.github/workflows/claude-comment-response.yml`, and `.github/workflows/claude-pr-creation.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fagentcontrolplane&utm_source=github&utm_medium=referral)<sup> for fe781d31a809fd88c01e2fa61a71ae405227eadd. You can [customize](https://app.ellipsis.dev/humanlayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->